### PR TITLE
leveraging experimental features for loading a chart from a registry

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -424,9 +424,8 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 
 	if err != nil {
 		panic(fmt.Sprintf("Unable to instantiate registry client: %v", err))
-		return err
 	}
 	cfg.RegistryClient = registryClient
 
-	return nil
+	return err
 }

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -416,5 +416,17 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 	cfg.Releases = store
 	cfg.Log = log
 
+	// Experimental: init registry client
+	var buf bytes.Buffer
+	registryClient, err := registry.NewClient(
+		registry.ClientOptWriter(&buf),
+	)
+
+	if err != nil {
+		panic(fmt.Sprintf("Unable to instantiate registry client: %v", err))
+		return err
+	}
+	cfg.RegistryClient = registryClient
+
 	return nil
 }

--- a/pkg/action/chart_load.go
+++ b/pkg/action/chart_load.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"helm.sh/helm/v3/internal/experimental/registry"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// ChartLoad performs a chart load operation.
+type ChartLoad struct {
+	cfg *Configuration
+}
+
+// NewChartLoad creates a new ChartLoad object with the given configuration.
+func NewChartLoad(cfg *Configuration) *ChartLoad {
+	return &ChartLoad{
+		cfg: cfg,
+	}
+}
+
+// Run executes the chart load operation
+func (a *ChartLoad) Run(ref string) (*chart.Chart, error) {
+	r, err := registry.ParseReference(ref)
+	if err != nil {
+		return nil, err
+	}
+	return a.cfg.RegistryClient.LoadChart(r)
+}


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

This PR allows M4D to load charts from a registry.
Changes:
- Updated Configuration object with a new RegistryWriter
- Added ChartLoad action for loading a chart from the registry