### PR TITLE
Expose OCI registry login/logout in 3.7 version

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -416,5 +416,16 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 	cfg.Releases = store
 	cfg.Log = log
 
+	// Experimental: init registry client
+	var buf bytes.Buffer
+	registryClient, err := registry.NewClient(
+		registry.ClientOptWriter(&buf),
+	)
+
+	if err != nil {
+		panic(fmt.Sprintf("Unable to instantiate registry client: %v", err))
+	}
+	cfg.RegistryClient = registryClient
+
 	return nil
 }

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -417,15 +417,17 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 	cfg.Log = log
 
 	// Experimental: init registry client
-	var buf bytes.Buffer
-	registryClient, err := registry.NewClient(
-		registry.ClientOptWriter(&buf),
-	)
+	if cfg.RegistryClient == nil {
+		var buf bytes.Buffer
+		registryClient, err := registry.NewClient(
+			registry.ClientOptWriter(&buf),
+		)
 
-	if err != nil {
-		panic(fmt.Sprintf("Unable to instantiate registry client: %v", err))
+		if err != nil {
+			panic(fmt.Sprintf("Unable to instantiate registry client: %v", err))
+		}
+		cfg.RegistryClient = registryClient
 	}
-	cfg.RegistryClient = registryClient
 
 	return nil
 }

--- a/pkg/action/pull.go
+++ b/pkg/action/pull.go
@@ -76,6 +76,10 @@ func NewPullWithOpts(opts ...PullOpt) *Pull {
 func (p *Pull) Run(chartRef string) (string, error) {
 	var out strings.Builder
 
+	if p.Settings == nil {
+		p.Settings = new(cli.EnvSettings)
+	}
+
 	c := downloader.ChartDownloader{
 		Out:     &out,
 		Keyring: p.Keyring,

--- a/pkg/action/registry_login.go
+++ b/pkg/action/registry_login.go
@@ -1,0 +1,44 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"io"
+
+	"helm.sh/helm/v3/internal/experimental/registry"
+)
+
+// Experimental: registry login original source is internal and thus this file
+// is used to expose registry login functions.
+
+// RegistryLogin performs a registry login operation.
+type RegistryLogin struct {
+	cfg *Configuration
+}
+
+// NewRegistryLogin creates a new RegistryLogin object with the given configuration.
+func NewRegistryLogin(cfg *Configuration) *RegistryLogin {
+	return &RegistryLogin{
+		cfg: cfg,
+	}
+}
+
+// Run executes the registry login operation
+func (a *RegistryLogin) Run(out io.Writer, hostname string, username string, password string, insecure bool) error {
+	return a.cfg.RegistryClient.Login(hostname, registry.LoginOptBasicAuth(username, password),
+		registry.LoginOptInsecure(insecure))
+}

--- a/pkg/action/registry_logout.go
+++ b/pkg/action/registry_logout.go
@@ -1,0 +1,41 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"io"
+)
+
+// Experimental: registry logout original source is internal and thus this file
+// is used to expose registry logout functions.
+
+// RegistryLogout performs a registry login operation.
+type RegistryLogout struct {
+	cfg *Configuration
+}
+
+// NewRegistryLogout creates a new RegistryLogout object with the given configuration.
+func NewRegistryLogout(cfg *Configuration) *RegistryLogout {
+	return &RegistryLogout{
+		cfg: cfg,
+	}
+}
+
+// Run executes the registry logout operation
+func (a *RegistryLogout) Run(out io.Writer, hostname string) error {
+	return a.cfg.RegistryClient.Logout(hostname)
+}


### PR DESCRIPTION
This PR exposes the OCI registry login/logout which became internal in helm 3.7.

It is required in order to support changes related to OCI registries done in helm 3.7: https://github.com/helm/community/blob/main/hips/hip-0006.md

After approval, the PR will be merged to branch fybrik-3.7, then a tag and a new release will be created.